### PR TITLE
Remove request params from cache key.

### DIFF
--- a/src/acachecontrol/cache.py
+++ b/src/acachecontrol/cache.py
@@ -14,6 +14,8 @@ from .exceptions import CacheException, TimeoutException
 logger = logging.getLogger(__name__)
 
 
+CACHEABLE_METHODS = ("HEAD", "GET")
+
 # Values below provided in seconds
 DEFAULT_MAX_AGE = 120
 DEFAULT_WAIT_TIMEOUT = 30
@@ -35,7 +37,7 @@ class AsyncCache:
         self.wait_timeout = config.get("wait_timeout", DEFAULT_WAIT_TIMEOUT)
         self.sleep_time = config.get("sleep_time", DEFAULT_SLEEP_TIME)
         self.cacheable_methods = config.get(
-            "cacheable_methods", ("HEAD", "GET")
+            "cacheable_methods", CACHEABLE_METHODS
         )
 
     def has_valid_entry(self, key: Tuple[str, str]) -> bool:

--- a/src/acachecontrol/request_context_manager.py
+++ b/src/acachecontrol/request_context_manager.py
@@ -33,6 +33,7 @@ class RequestContextManager:
         self.headers = None
 
     async def text(self):
+        """Return response in plain str format."""
         if not self.cache.has_valid_entry(self.key):
             response = await self.response.text()
             self.cache.add(self.key, self.response, self.headers)
@@ -41,6 +42,7 @@ class RequestContextManager:
         return response
 
     async def json(self):
+        """Return response in json format."""
         if not self.cache.has_valid_entry(self.key):
             response = await self.response.json()
             self.cache.add(self.key, self.response, self.headers)

--- a/src/acachecontrol/request_context_manager.py
+++ b/src/acachecontrol/request_context_manager.py
@@ -7,7 +7,8 @@ class RequestContextManager:
         self.url = url
         self.params = params
         self.client_session = client_session
-        self.key = (method, url, params)
+        # TODO: consider canonify url
+        self.key = (method, url)
         self.response = None
         self.headers = None
 

--- a/tests/integration/test_acachecontrol.py
+++ b/tests/integration/test_acachecontrol.py
@@ -15,7 +15,7 @@ class CacheObserver(AsyncCache):
         self.add_calls.append((key, value, headers))
 
     def get(self, key):
-        value = self.cache.get(self._make_key_hashable(key))["value"]
+        value = self.cache.get(key)["value"]
         self.get_calls.append(key)
         return value
 
@@ -62,7 +62,7 @@ async def test_hit_cache():
             assert resp.status == 200
             assert "Example Domain" in resp_text
 
-        assert ("GET", "http://example.com", {}) in cache_observer.get_calls
+        assert ("GET", "http://example.com") in cache_observer.get_calls
 
 
 @pytest.mark.asyncio
@@ -112,4 +112,4 @@ async def test_hit_cache_json():
             assert resp.status == 200
             assert resp_json == expected_json
 
-        assert ("GET", url, {}) in cache_observer.get_calls
+        assert ("GET", url) in cache_observer.get_calls

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -8,18 +8,14 @@ def test_add_happy_path(monkeypatch):
     monkeypatch.setattr(time, "time", lambda: current_timestamp)
     acache = AsyncCache()
     acache.add(
-        key=("GET", "test_url", {"data": "test_data"}),
+        key=("GET", "test_url"),
         value="test_response",
         headers={
             "Cache-Control": "max-age=604800",
             "Content-Type": "text/html; charset=UTF-8",
         },
     )
-    cache_key = (
-        "GET",
-        "test_url",
-        "95f4fd1dd8c46219f8cbb42419a2dc53317f6eb3b95711a752773c042f623483",
-    )
+    cache_key = ("GET", "test_url")
     assert cache_key in acache.cache
     assert acache.cache[cache_key]["created_at"] == current_timestamp
     assert acache.cache[cache_key]["max-age"] == 604800
@@ -29,7 +25,7 @@ def test_add_happy_path(monkeypatch):
 def test_non_cacheable_method():
     acache = AsyncCache()
     acache.add(
-        key=("test_method", "test_url", {"data": "test_data"}),
+        key=("test_method", "test_url"),
         value="test_response",
         headers={
             "Cache-Control": "max-age=604800",
@@ -42,7 +38,7 @@ def test_non_cacheable_method():
 def test_add_no_cache():
     acache = AsyncCache()
     acache.add(
-        key=("GET", "test_url", {"data": "test_data"}),
+        key=("GET", "test_url"),
         value="test_response",
         headers={
             "Cache-Control": "max-age=604800,no-cache",
@@ -52,7 +48,7 @@ def test_add_no_cache():
     assert len(acache.cache) == 0
 
     acache.add(
-        key=("GET", "test_url", {"data": "test_data"}),
+        key=("GET", "test_url"),
         value="test_response",
         headers={
             "Cache-Control": "max-age=604800,no-store",


### PR DESCRIPTION
As we cache only HEAD and GET, we don't need request parameters anymore.