### PR TITLE
Updated docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ from acachecontrol import AsyncCacheControl
 
 async def main():
     async with AsyncCacheControl() as cached_sess:
-        async with cached_sess.request('GET', 'http://example.com') as resp:
+        async with cached_sess.get('http://example.com') as resp:
             resp_text = await resp.text()
             print(resp_text)
 

--- a/README.md
+++ b/README.md
@@ -16,11 +16,14 @@ There is a good and simple library [CacheControl](https://github.com/ionrock/cac
 
 ```py
 import asyncio
-from acachecontrol import AsyncCacheControl
+from acachecontrol import AsyncCache, AsyncCacheControl
 
 
 async def main():
-    async with AsyncCacheControl() as cached_sess:
+    cache = AsyncCache(config={"sleep_time": 0.2})
+    # `AsyncCache()` with default configuration is used
+    # if `cache` not provided
+    async with AsyncCacheControl(cache=cache) as cached_sess:
         async with cached_sess.get('http://example.com') as resp:
             resp_text = await resp.text()
             print(resp_text)

--- a/src/acachecontrol/__init__.py
+++ b/src/acachecontrol/__init__.py
@@ -2,3 +2,4 @@ __version__ = "0.2.0"
 
 
 from .acachecontrol import AsyncCacheControl  # noqa
+from .cache import AsyncCache  # noqa

--- a/src/acachecontrol/acachecontrol.py
+++ b/src/acachecontrol/acachecontrol.py
@@ -14,32 +14,32 @@ class AsyncCacheControl:
         self.cache = cache
         self._async_client_session = aiohttp.ClientSession()
 
-    def request(self, method, url, **params):
+    def _request(self, method, url, **params):
         return self._request_context_manager_cls(
             self._async_client_session, self.cache, method, url, **params
         )
 
     def head(self, url, allow_redirects=True, **params):
-        return self.request(
+        return self._request(
             "HEAD", url, allow_redirects=allow_redirects, **params
         )
 
     def get(self, url, allow_redirects=True, **params):
-        return self.request(
+        return self._request(
             "GET", url, allow_redirects=allow_redirects, **params
         )
 
     def post(self, url, data, **params):
-        return self.request("POST", url, data=data, **params)
+        return self._request("POST", url, data=data, **params)
 
     def put(self, url, data, **params):
-        return self.request("PUT", url, data=data, **params)
+        return self._request("PUT", url, data=data, **params)
 
     def patch(self, url, data, **params):
-        return self.request("PATCH", url, data=data, **params)
+        return self._request("PATCH", url, data=data, **params)
 
     def delete(self, url, **params):
-        return self.request("DELETE", url, **params)
+        return self._request("DELETE", url, **params)
 
     def clear_cache(self):
         self.cache.clear_cache()

--- a/src/acachecontrol/acachecontrol.py
+++ b/src/acachecontrol/acachecontrol.py
@@ -7,39 +7,39 @@ from .request_context_manager import RequestContextManager
 class AsyncCacheControl:
     def __init__(
         self,
+        cache: AsyncCache = AsyncCache(),
         request_context_manager_cls=RequestContextManager,
-        cache=AsyncCache(),
     ):
         self._request_context_manager_cls = request_context_manager_cls
         self.cache = cache
         self._async_client_session = aiohttp.ClientSession()
 
-    def _request(self, method, url, **params):
+    def request(self, method, url, **params):
         return self._request_context_manager_cls(
             self._async_client_session, self.cache, method, url, **params
         )
 
     def head(self, url, allow_redirects=True, **params):
-        return self._request(
+        return self.request(
             "HEAD", url, allow_redirects=allow_redirects, **params
         )
 
     def get(self, url, allow_redirects=True, **params):
-        return self._request(
+        return self.request(
             "GET", url, allow_redirects=allow_redirects, **params
         )
 
     def post(self, url, data, **params):
-        return self._request("POST", url, data=data, **params)
+        return self.request("POST", url, data=data, **params)
 
     def put(self, url, data, **params):
-        return self._request("PUT", url, data=data, **params)
+        return self.request("PUT", url, data=data, **params)
 
     def patch(self, url, data, **params):
-        return self._request("PATCH", url, data=data, **params)
+        return self.request("PATCH", url, data=data, **params)
 
     def delete(self, url, **params):
-        return self._request("DELETE", url, **params)
+        return self.request("DELETE", url, **params)
 
     def clear_cache(self):
         self.cache.clear_cache()

--- a/src/acachecontrol/cache.py
+++ b/src/acachecontrol/cache.py
@@ -7,7 +7,7 @@ import hashlib
 import json
 import logging
 import time
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, Set, Tuple
 
 from .exceptions import CacheException, TimeoutException
 
@@ -30,15 +30,16 @@ class AsyncCache:
     Key: Tuple(http_method, url), value: aiohttp response obj
     """
 
-    def __init__(self, config={}):
+    def __init__(self, config: Dict = None):
         self.cache = {}  # type: Dict
-        self._wait_until_completed = set()
-        self.default_max_age = config.get("max_age", DEFAULT_MAX_AGE)
-        self.wait_timeout = config.get("wait_timeout", DEFAULT_WAIT_TIMEOUT)
-        self.sleep_time = config.get("sleep_time", DEFAULT_SLEEP_TIME)
-        self.cacheable_methods = config.get(
-            "cacheable_methods", CACHEABLE_METHODS
-        )
+        self._wait_until_completed = set()  # type: Set
+        if config:
+            self.default_max_age = config.get("max_age", DEFAULT_MAX_AGE)
+            self.wait_timeout = config.get("wait_timeout", DEFAULT_WAIT_TIMEOUT)
+            self.sleep_time = config.get("sleep_time", DEFAULT_SLEEP_TIME)
+            self.cacheable_methods = config.get(
+                "cacheable_methods", CACHEABLE_METHODS
+            )
 
     def has_valid_entry(self, key: Tuple[str, str]) -> bool:
         """Check if entry exists and not expired, delete expired."""

--- a/src/acachecontrol/cache.py
+++ b/src/acachecontrol/cache.py
@@ -32,14 +32,14 @@ class AsyncCache:
 
     def __init__(self, config: Dict = None):
         self.cache = {}  # type: Dict
+        config = config or {}
         self._wait_until_completed = set()  # type: Set
-        if config:
-            self.default_max_age = config.get("max_age", DEFAULT_MAX_AGE)
-            self.wait_timeout = config.get("wait_timeout", DEFAULT_WAIT_TIMEOUT)
-            self.sleep_time = config.get("sleep_time", DEFAULT_SLEEP_TIME)
-            self.cacheable_methods = config.get(
-                "cacheable_methods", CACHEABLE_METHODS
-            )
+        self.default_max_age = config.get("max_age", DEFAULT_MAX_AGE)
+        self.wait_timeout = config.get("wait_timeout", DEFAULT_WAIT_TIMEOUT)
+        self.sleep_time = config.get("sleep_time", DEFAULT_SLEEP_TIME)
+        self.cacheable_methods = config.get(
+            "cacheable_methods", CACHEABLE_METHODS
+        )
 
     def has_valid_entry(self, key: Tuple[str, str]) -> bool:
         """Check if entry exists and not expired, delete expired."""

--- a/src/acachecontrol/cache.py
+++ b/src/acachecontrol/cache.py
@@ -3,8 +3,6 @@
 Current implementation is just a draft, wrapper around simple dict.
 """
 import asyncio
-import hashlib
-import json
 import logging
 import time
 from typing import Any, Dict, Set, Tuple

--- a/tests/integration/test_acachecontrol.py
+++ b/tests/integration/test_acachecontrol.py
@@ -23,7 +23,7 @@ class CacheObserver(AsyncCache):
 @pytest.mark.asyncio
 async def test_request():
     async with AsyncCacheControl() as cached_sess:
-        async with cached_sess.request("GET", "http://example.com") as resp:
+        async with cached_sess.get("http://example.com") as resp:
             resp_text = await resp.text()
             assert resp.status == 200
             assert "Example Domain" in resp_text
@@ -52,12 +52,12 @@ async def test_get():
 async def test_hit_cache():
     cache_observer = CacheObserver()
     async with AsyncCacheControl(cache=cache_observer) as cached_sess:
-        async with cached_sess.request("GET", "http://example.com") as resp:
+        async with cached_sess.get("http://example.com") as resp:
             resp_text = await resp.text()
             assert resp.status == 200
             assert "Example Domain" in resp_text
 
-        async with cached_sess.request("GET", "http://example.com") as resp:
+        async with cached_sess.get("http://example.com") as resp:
             resp_text = await resp.text()
             assert resp.status == 200
             assert "Example Domain" in resp_text
@@ -76,12 +76,12 @@ async def test_no_hit_cache():
     ]
     cache_observer = CacheObserver()
     async with AsyncCacheControl(cache=cache_observer) as cached_sess:
-        async with cached_sess.request("GET", url) as resp:
+        async with cached_sess.get(url) as resp:
             resp_json = await resp.json()
             assert resp.status == 200
             assert resp_json == expected_json
 
-        async with cached_sess.request("GET", url) as resp:
+        async with cached_sess.get(url) as resp:
             resp_json = await resp.json()
             assert resp.status == 200
             assert resp_json == expected_json
@@ -100,14 +100,14 @@ async def test_hit_cache_json():
     ]
     cache_observer = CacheObserver()
     async with AsyncCacheControl(cache=cache_observer) as cached_sess:
-        async with cached_sess.request("GET", url) as resp:
+        async with cached_sess.get(url) as resp:
             # clean headers to force cache response
             resp.headers = {}
             resp_json = await resp.json()
             assert resp.status == 200
             assert resp_json == expected_json
 
-        async with cached_sess.request("GET", url) as resp:
+        async with cached_sess.get(url) as resp:
             resp_json = await resp.json()
             assert resp.status == 200
             assert resp_json == expected_json

--- a/tests/unit/test_acachecontrol.py
+++ b/tests/unit/test_acachecontrol.py
@@ -10,7 +10,7 @@ async def test_request(mocker):
     async with AsyncCacheControl(
         request_context_manager_cls=mock_RCM
     ) as cached_sess:
-        _ = cached_sess.request("GET", "http://example.com")
+        _ = cached_sess.get("http://example.com")
         mock_RCM.assert_called_with(
             cached_sess._async_client_session,
             cached_sess.cache,
@@ -18,9 +18,7 @@ async def test_request(mocker):
             "http://example.com",
         )
 
-        _ = cached_sess.request(
-            "POST", "http://example.com", data={"key": "value"}
-        )
+        _ = cached_sess.poet("http://example.com", data={"key": "value"})
         mock_RCM.assert_called_with(
             cached_sess._async_client_session,
             cached_sess.cache,

--- a/tests/unit/test_acachecontrol.py
+++ b/tests/unit/test_acachecontrol.py
@@ -1,6 +1,33 @@
 import pytest
 
-from acachecontrol import AsyncCacheControl
+from acachecontrol import AsyncCache, AsyncCacheControl
+
+
+@pytest.mark.asyncio
+async def test_request(mocker):
+    """Verify AsyncCacheControl.request works correctly."""
+    mock_RCM = mocker.Mock()
+    async with AsyncCacheControl(
+        cache=AsyncCache(), request_context_manager_cls=mock_RCM
+    ) as cached_sess:
+        _ = cached_sess.request("GET", "http://example.com")
+        mock_RCM.assert_called_with(
+            cached_sess._async_client_session,
+            cached_sess.cache,
+            "GET",
+            "http://example.com",
+        )
+
+        _ = cached_sess.request(
+            "POST", "http://example.com", data={"key": "value"}
+        )
+        mock_RCM.assert_called_with(
+            cached_sess._async_client_session,
+            cached_sess.cache,
+            "POST",
+            "http://example.com",
+            data={"key": "value"},
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_acachecontrol.py
+++ b/tests/unit/test_acachecontrol.py
@@ -4,31 +4,6 @@ from acachecontrol import AsyncCacheControl
 
 
 @pytest.mark.asyncio
-async def test_request(mocker):
-    """Verify AsyncCacheControl.request works correctly."""
-    mock_RCM = mocker.Mock()
-    async with AsyncCacheControl(
-        request_context_manager_cls=mock_RCM
-    ) as cached_sess:
-        _ = cached_sess.get("http://example.com")
-        mock_RCM.assert_called_with(
-            cached_sess._async_client_session,
-            cached_sess.cache,
-            "GET",
-            "http://example.com",
-        )
-
-        _ = cached_sess.poet("http://example.com", data={"key": "value"})
-        mock_RCM.assert_called_with(
-            cached_sess._async_client_session,
-            cached_sess.cache,
-            "POST",
-            "http://example.com",
-            data={"key": "value"},
-        )
-
-
-@pytest.mark.asyncio
 async def test_head(mocker):
     """Verify AsyncCacheControl.head works correctly."""
     mock_RCM = mocker.Mock()


### PR DESCRIPTION
I think we should not expose `cached_sess.request()` to users and encourage them to use verb-related methods.