### PR TITLE
Have cache-control header header correctly extract max-age when it is non-first directive when spaces follow commas

### DIFF
--- a/src/acachecontrol/cache.py
+++ b/src/acachecontrol/cache.py
@@ -164,7 +164,7 @@ class AsyncCache:
             if cleaned_directive in ("no-cache", "no-store"):
                 parsed_header[cleaned_directive] = True
             elif "=" in cleaned_directive:
-                key, value = directive.split("=", 1)
+                key, value = cleaned_directive.split("=", 1)
                 if "max-age" == key:
                     try:
                         parsed_header["max-age"] = int(value)


### PR DESCRIPTION
Without this change, in the below example max-age is not extracted because it is preceded by a space, so key is `" max-age"`:
```
acachecontrol.cache.AsyncCache.parse_cache_control_header({'cache-control': 'public, max-age=21359, must-revalidate, no-transform'})
{}
```
With this change, max-age is properly extracted because we use the stripped representation, so key is `"max-age"`:
```
acachecontrol.cache.AsyncCache.parse_cache_control_header({'cache-control': 'public, max-age=21359, must-revalidate, no-transform'})
{'max-age': 21359}
```
