### PR TITLE
Fix usage of custom cache backend. Add Copyright headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ class CustomCacheBackend():
         self.storage[key] = value
         self.item_order.append(key)
 
+    def get(self, key):
+        return self.storage.get(key)
+
     def pop(self, key):
         self.item_order.remove(key)
         return self.storage.pop(key)

--- a/src/acachecontrol/acachecontrol.py
+++ b/src/acachecontrol/acachecontrol.py
@@ -1,3 +1,20 @@
+"""
+Copyright 2021 - Present Serhii Buniak
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+
 import aiohttp
 
 from .cache import AsyncCache

--- a/src/acachecontrol/cache.py
+++ b/src/acachecontrol/cache.py
@@ -1,7 +1,20 @@
-"""Cache implementation for async app.
-
-Current implementation is a wrapper over OrderedDict object, implements LRU cache.
 """
+Copyright 2021 - Present Serhii Buniak
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+
 import asyncio
 import logging
 import time
@@ -23,12 +36,16 @@ logger = logging.getLogger(__name__)
 class AsyncCache:
     """Asynchronous Cache implementation.
 
+    Current implementation is a wrapper over OrderedDict object, implements LRU cache.
     Supports any OrderedDict-like object as cache_backend.
+
     Key: Tuple(http_method, url), value: aiohttp response obj
     """
 
     def __init__(self, config: Dict = None, cache_backend=None):
-        self.cache = cache_backend if cache_backend else OrderedDict()
+        self.cache = (
+            cache_backend if cache_backend is not None else OrderedDict()
+        )
         config = config or {}
         self._wait_until_completed = set()  # type: Set
         self.default_max_age = config.get("max_age", DEFAULT_MAX_AGE)

--- a/src/acachecontrol/constants.py
+++ b/src/acachecontrol/constants.py
@@ -1,5 +1,19 @@
-"""Common constants used across different modules.
 """
+Copyright 2021 - Present Serhii Buniak
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
 CACHEABLE_METHODS = ("HEAD", "GET")
 
 # Values below provided in seconds

--- a/src/acachecontrol/exceptions.py
+++ b/src/acachecontrol/exceptions.py
@@ -1,3 +1,20 @@
+"""
+Copyright 2021 - Present Serhii Buniak
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+
 class BaseACacheControlException(Exception):
     pass
 

--- a/src/acachecontrol/request_context_manager.py
+++ b/src/acachecontrol/request_context_manager.py
@@ -1,3 +1,20 @@
+"""
+Copyright 2021 - Present Serhii Buniak
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+
 from .constants import DEFAULT_WAIT_TIMEOUT
 
 


### PR DESCRIPTION
Fix usage of custom cache backend (add check "is not None"):
the following line:
```py
     self.cache = cache_backend if cache_backend else OrderedDict()
```
changed to:
```py
        self.cache = (
            cache_backend if cache_backend is not None else OrderedDict()
        )
```


Add Copyright headers to apply Apache License as described here: https://opensource.org/licenses/Apache-2.0